### PR TITLE
Fix element overlapping

### DIFF
--- a/src/DjPanel.css
+++ b/src/DjPanel.css
@@ -1,0 +1,3 @@
+.dj-pic {
+    max-height: 720px;
+}

--- a/src/DjPanel.js
+++ b/src/DjPanel.js
@@ -20,7 +20,7 @@ const styles = {
         marginBottom: 10,
         display: 'block',
         marginLeft: 'auto',
-        marginRight: 'auto'
+        marginRight: 'auto',
     },
     container: {
         justifyContent: 'center',
@@ -41,7 +41,7 @@ const DjPanel = () => (
         const api = data.api;
         return (
             <div style={styles.container}>
-                <img src={misc.dj_image_link} alt="dj_pic" style={styles.img} />
+                <img src={misc.dj_image_link} alt="dj_pic" style={styles.img} class="dj-pic" />
                 <Typography gutterBottom variant="h4" component="h2" align="center">
                     Current DJ: {api.dj_name}
                 </Typography>

--- a/src/MainPageCenterPanel.js
+++ b/src/MainPageCenterPanel.js
@@ -31,7 +31,6 @@ const useStyles = makeStyles(theme => ({
     root: {
         flexGrow: 1,
         backgroundColor: theme.palette.background.paper,
-        position: 'fixed',
     },
 }));
 

--- a/src/ServerHeader.js
+++ b/src/ServerHeader.js
@@ -42,8 +42,8 @@ const useStyles = makeStyles(theme => ({
 export default function ServerHeader() {
   const classes = useStyles();
   return (
-    <div className={classes.root}>
-      <AppBar position="static">
+    <React.Fragment>
+      <AppBar position="static" className={classes.root}>
         <Toolbar variant="dense">
             <Typography
                 variant="h6"
@@ -70,6 +70,6 @@ export default function ServerHeader() {
         </Toolbar>
         {/* {renderMenu} */}
       </AppBar>
-    </div>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION
- Fixes the top header element being overlapped by main text/image content.
- Sets the tab buttons to no longer be fixed so that they don't overlap text/image content.
- Sets the max size of the DJ image for certain cases (yorozuya)